### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/src/Cake.LongPath.Module/Cake.LongPath.Module.csproj
+++ b/src/Cake.LongPath.Module/Cake.LongPath.Module.csproj
@@ -31,12 +31,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.16.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.16.2\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Pri.LongPath, Version=2.0.40.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Pri.LongPath.2.0.40\lib\net45\Pri.LongPath.dll</HintPath>
+    <Reference Include="Pri.LongPath, Version=2.0.42.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pri.LongPath.2.0.42\lib\net45\Pri.LongPath.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Cake.LongPath.Module/LongPathDirectory.cs
+++ b/src/Cake.LongPath.Module/LongPathDirectory.cs
@@ -38,6 +38,15 @@ namespace Cake.LongPath.Module
         }
 
         /// <summary>
+        /// Moves the directory to the specified destination path.
+        /// </summary>
+        /// <param name="destination">The destination path.</param>
+        public void Move(DirectoryPath destination)
+        {
+            Directory.MoveTo(destination.FullPath);
+        }
+
+        /// <summary>
         /// Deletes the directory.
         /// </summary>
         /// <param name="recursive">Will perform a recursive delete if set to <c>true</c>.</param>

--- a/src/Cake.LongPath.Module/packages.config
+++ b/src/Cake.LongPath.Module/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.16.2" targetFramework="net452" />
-  <package id="Pri.LongPath" version="2.0.40" targetFramework="net452" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net452" />
+  <package id="Pri.LongPath" version="2.0.42" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.

Added required move directory