### PR TITLE
Workaround Pri.LongPath regression on DirectoryInfo.Exists.

### DIFF
--- a/src/Cake.LongPath.Module/LongPathDirectory.cs
+++ b/src/Cake.LongPath.Module/LongPathDirectory.cs
@@ -26,7 +26,22 @@ namespace Cake.LongPath.Module
         /// <value>The path.</value>
         Path IFileSystemInfo.Path => Path;
 
-        public bool Exists => Directory.Exists;
+        public bool Exists
+        {
+            get
+            {
+                // Workaround until https://github.com/peteraritchie/LongPath/issues/82 is fixed
+                try
+                {
+                    return Directory.Exists;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
         public bool Hidden => (Directory.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden;
 
         /// <summary>


### PR DESCRIPTION
Temporary workaround for #15 until https://github.com/peteraritchie/LongPath/issues/82 is fixed